### PR TITLE
[tests,iamserver] Fix cSecretLen usage in tests

### DIFF
--- a/tests/iamserver/iamserver_test.cpp
+++ b/tests/iamserver/iamserver_test.cpp
@@ -364,7 +364,7 @@ TEST_F(IAMServerTest, RegisterInstanceSucceeds)
     RegisterInstanceResponse response;
 
     EXPECT_CALL(mPermHandler, RegisterInstance)
-        .WillOnce(Return(RetWithError<StaticString<uuid::cUUIDLen>>("test-secret")));
+        .WillOnce(Return(RetWithError<StaticString<aos::iam::permhandler::cSecretLen>>("test-secret")));
 
     const auto status = clientStub->RegisterInstance(&context, request, &response);
     ASSERT_TRUE(status.ok()) << status.error_message() << " (" << status.error_code() << ")";
@@ -412,7 +412,7 @@ TEST_F(IAMServerTest, RegisterInstanceFailsOnPermHandler)
     RegisterInstanceResponse response;
 
     EXPECT_CALL(mPermHandler, RegisterInstance)
-        .WillOnce(Return(RetWithError<StaticString<uuid::cUUIDLen>>("", aos::ErrorEnum::eFailed)));
+        .WillOnce(Return(RetWithError<StaticString<aos::iam::permhandler::cSecretLen>>("", aos::ErrorEnum::eFailed)));
 
     const auto status = clientStub->RegisterInstance(&context, request, &response);
     ASSERT_FALSE(status.ok()) << status.error_message() << " (" << status.error_code() << ")";

--- a/tests/include/mocks/permissionhandlermock.hpp
+++ b/tests/include/mocks/permissionhandlermock.hpp
@@ -20,7 +20,7 @@ namespace permhandler {
  */
 class PermHandlerMock : public PermHandlerItf {
 public:
-    MOCK_METHOD(RetWithError<StaticString<uuid::cUUIDLen>>, RegisterInstance,
+    MOCK_METHOD(RetWithError<StaticString<cSecretLen>>, RegisterInstance,
         (const InstanceIdent& instanceIdent, const Array<FunctionalServicePermissions>& instancePermissions),
         (override));
     MOCK_METHOD(Error, UnregisterInstance, (const InstanceIdent& instanceIdent), (override));


### PR DESCRIPTION
cSecretLen const was added instead of uuid::cUUIDLen. Update tests to use cSecretLen.